### PR TITLE
Fix printer availability handling in state sensor

### DIFF
--- a/custom_components/flashforge_adventurer_3/sensor.py
+++ b/custom_components/flashforge_adventurer_3/sensor.py
@@ -97,7 +97,7 @@ class BaseFlashforgeAdventurer3Sensor(FlashforgeAdventurer3CommonPropertiesMixin
     @callback
     def _handle_coordinator_update(self) -> None:
         self.attrs = self.coordinator.data
-        self.async_write_ha_state()
+        super()._handle_coordinator_update()
 
 
 class FlashforgeAdventurer3StateSensor(BaseFlashforgeAdventurer3Sensor):
@@ -111,7 +111,7 @@ class FlashforgeAdventurer3StateSensor(BaseFlashforgeAdventurer3Sensor):
 
     @property
     def available(self) -> bool:
-        return True
+        return bool(self.attrs.get('online'))
 
     @property
     def state(self) -> Optional[str]:


### PR DESCRIPTION
## Summary
- evaluate state sensor availability based on printer online flag
- set coordinator attributes before triggering update to ensure availability uses fresh data

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68945bb33948832c82e0225e1168c65a