### PR TITLE
Use ip_address key in sensor schema

### DIFF
--- a/custom_components/flashforge_adventurer_3/sensor.py
+++ b/custom_components/flashforge_adventurer_3/sensor.py
@@ -21,13 +21,14 @@ LOGGER = logging.getLogger(__name__)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required('ip'): cv.string,
+        vol.Required('ip_address'): cv.string,
         vol.Required('port'): cv.string,
     }
 )
 
+
 class PrinterDefinition(TypedDict):
-    ip: str
+    ip_address: str
     port: int
 
 
@@ -67,7 +68,7 @@ class FlashforgeAdventurer3Coordinator(DataUpdateCoordinator):
 class FlashforgeAdventurer3CommonPropertiesMixin:
     @property
     def name(self) -> str:
-        return f'FlashForge Adventurer 3'
+        return 'FlashForge Adventurer 3'
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
## Summary
- ensure `PrinterDefinition` uses `ip_address`
- expect `ip_address` in `PLATFORM_SCHEMA`

## Testing
- `pytest`
- `flake8` *(fails: config_flow.py:5:1 F401 'homeassistant.const.CONF_TYPE' imported but unused, config_flow.py:6:1 F401 'homeassistant.helpers.selector' imported but unused, protocol.py:16:55 W605 invalid escape sequence '\\w', protocol.py:16:74 W605 invalid escape sequence '\\d', protocol.py:16:80 W605 invalid escape sequence '\\d', protocol.py:17:65 W605 invalid escape sequence '\\d', protocol.py:17:69 W605 invalid escape sequence '\\W', protocol.py:17:74 W605 invalid escape sequence '\\d', protocol.py:17:82 W605 invalid escape sequence '\\d', protocol.py:17:86 W605 invalid escape sequence '\\W', protocol.py:17:91 W605 invalid escape sequence '\\d', protocol.py:19:1 E302 expected 2 blank lines, found 1, protocol.py:44:17 E201 whitespace after '{', protocol.py:44:33 E202 whitespace before '}', protocol.py:45:32 E201 whitespace after '{', protocol.py:45:47 E202 whitespace before '}' )


------
https://chatgpt.com/codex/tasks/task_e_689472818a44832ca2b16edadffbc11f